### PR TITLE
Fix typo and use en dash.

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,8 +9,8 @@ country: "fr"      # lowercase two-letter ISO country code such as "fr" (see htt
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the workshop
 latitude: "48.577718205129045"        # decimal latitude of workshop venue (use https://www.latlong.net/)
 longitude: "7.747757101847314"       # decimal longitude of the workshop venue (use https://www.latlong.net)
-humandate: "Oct 17-18, 2024"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
-humantime: "9:00 an - 5:00 pm CEST"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST (7:00 am - 2:30 pm UTC)"
+humandate: "Oct 17–18, 2024"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
+humantime: "9:00am – 5:00pm CEST"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST (7:00 am - 2:30 pm UTC)"
 startdate: 2024-10-17      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2024-10-18        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["Marianne Corvellec", "Marie Houillon"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]


### PR DESCRIPTION
I believe no space before am/pm is more standard; same for en dash between figures to show a range (for example, 1939–45).